### PR TITLE
Update SRID value to make more sense for geographic queries

### DIFF
--- a/generic.resoscript
+++ b/generic.resoscript
@@ -196,7 +196,7 @@
 
     <!-- Platinum - GeoSpatial query values -->
     <Parameter Name="GeoSpatialDistanceValue" Value="1000" />
-    <Parameter Name="SRID" Value="0" />
+    <Parameter Name="SRID" Value="4326" />
 
 
     <!--


### PR DESCRIPTION
Since the tests use `geography` I think it makes more sense to test `SRID=4326` since that's a geographic projection. Alternatively, I think it makes sense to pair the `geometry` prefix with `SRID=0`

Signed-off-by: Eric Finlay <eric@rets.ly>