### PR TITLE
Provide better Windows support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ task testDataDictionary_1_7() {
           '--glue',
           'org.reso.certification.stepdefs#DataDictionary',
           'src/main/java/org/reso/certification/features/data-dictionary/v1-7-0',
-          '--tags',
+          (systemProperties.get('cucumber.filter.tags', '').toString().trim().length() > 0 ? '--tags' : ''),
           (systemProperties.get('cucumber.filter.tags', '').toString().trim().length() > 0
               ? systemProperties.get('cucumber.filter.tags') : '')
       ]

--- a/src/main/java/org/reso/certification/stepdefs/DataDictionary.java
+++ b/src/main/java/org/reso/certification/stepdefs/DataDictionary.java
@@ -22,6 +22,7 @@ import org.reso.models.Settings;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -439,7 +440,7 @@ public class DataDictionary {
   }
 
   @And("{string} MUST contain only standard enumerations")
-  public void mustContainOnlyStandardEnumerations(String fieldName) {
+  public void mustContainOnlyStandardEnumerations(String fieldName) throws URISyntaxException {
     final String REFERENCE_ENUMS_NAMESPACE = "org.reso.metadata.enums";
     FullQualifiedName fqn = container.getFieldMap().get(currentResourceName.get()).get(fieldName).getTypeAsFQNObject();
 
@@ -491,12 +492,13 @@ public class DataDictionary {
   }
 
   XMLMetadata referenceMetadata = null;
-  private XMLMetadata getReferenceMetadata() {
+  private XMLMetadata getReferenceMetadata() throws URISyntaxException {
     if (referenceMetadata == null) {
       URL resource = Thread.currentThread().getContextClassLoader().getResource(REFERENCE_METADATA);
       assert resource != null;
+      String path = new File(resource.toURI()).toString();
       referenceMetadata = Commander
-          .deserializeXMLMetadata(Commander.convertInputStreamToString(Commander.deserializeFileFromPath(resource.getPath())),
+          .deserializeXMLMetadata(Commander.convertInputStreamToString(Commander.deserializeFileFromPath(path)),
               container.getCommander().getClient());
     }
     return referenceMetadata;


### PR DESCRIPTION
These are the two changes I needed to make in order to get this running on Windows.

Without the change in build.gradle, cucumber would fail about an empty --tags parameter.

The change in getReferenceMetadata() was to deal with the fact that URL.getPath() was returning something like `/C:/Users/jbramley/...`.