### PR TITLE
Use FuzzyWuzzy for fuzzy string comparison

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ dependencies {
   compile 'org.apache.commons:commons-text:1.9'
 
   implementation 'org.mockito:mockito-core:3.3.3'
+  compile 'me.xdrop:fuzzywuzzy:1.3.1'
+
 }
 
 configurations {

--- a/src/main/java/org/reso/certification/stepdefs/DataDictionary.java
+++ b/src/main/java/org/reso/certification/stepdefs/DataDictionary.java
@@ -4,7 +4,7 @@ import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.*;
-import org.apache.commons.text.similarity.LevenshteinDistance;
+import me.xdrop.fuzzywuzzy.FuzzySearch;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -480,7 +480,10 @@ public class DataDictionary {
 
     for (String nonstandardField : difference) {
       for (String lookupName : currentLookups.get().keySet()) {
-        if (LevenshteinDistance.getDefaultInstance().apply(lookupName, nonstandardField) < getDistanceThreshold(lookupName)) {
+        if (nonstandardField.endsWith(lookupName)) {
+          continue;
+        }
+        if (lookupName.equalsIgnoreCase(nonstandardField) || FuzzySearch.ratio(lookupName, nonstandardField) > 85) {
           similarMembers.put(lookupName, foundMembers.get().get(nonstandardField));
         }
       }


### PR DESCRIPTION
In running through the "similar" lookup values, I found that Levenshtein distance by itself was not providing a sufficient heuristic. After fiddling with some other methods, I used the FuzzyWuzzy library to provide a better heuristic. From what I can tell, while still not perfect, this methodology is working a lot better for me.