### PR TITLE
Issue #45 - fix handling of all() so result either contains asserted value OR the empty list

### DIFF
--- a/src/main/java/org/reso/certification/features/web-api/web-api-server.core.1.0.2.feature
+++ b/src/main/java/org/reso/certification/features/web-api/web-api-server.core.1.0.2.feature
@@ -413,7 +413,7 @@ Feature: Web API Server 1.0.2 Core Certification
     And the response has results
     And resource metadata for "Parameter_EndpointResource" contains the fields in the given select list
     And data are present for fields contained within the given select list
-    And Multiple Valued Enumeration Data in "Parameter_MultipleValueLookupField" has "Parameter_MultipleLookupValue1"
+    And Multiple Valued Enumeration Data in "Parameter_MultipleValueLookupField" is empty OR has "Parameter_MultipleLookupValue1"
 
   @filter-enum-single-has @2.4.9
   Scenario: filter-enum-single-has - Support Single Value Lookups


### PR DESCRIPTION
As outlined recently in the Transport and Certification workgroup discussions, the [OData `all()` operator](http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part2-url-conventions/odata-v4.0-errata03-os-part2-url-conventions-complete.html#_Toc371341807) should allow either an exact match on the items specified OR the empty list. 

For example, if a search for `$filter=Appliances/all(l:l eq 'Washer')` were requested, then the following response is valid:

```
{
  "@odata.context": "https://api.server.com?$select=ListingKey,Appliances&$filter=Appliances/all(l:l eq 'Washer')",
  "value": [{
    "ListingKey": "a1",
    "Appliances": ["Washer"]
  }, {
    "ListingKey": "b2,
    "Appliances": []
  }]
}
```  

As is:
```
{
  "@odata.context": "https://api.server.com?$select=ListingKey,Appliances&$filter=Appliances/all(l:l eq 'Washer')",
  "value": [{
    "ListingKey": "a1",
    "Appliances": []
  }, {
    "ListingKey": "b2,
    "Appliances": []
  }]
}
```  

But the following response is not:
```
{
  "@odata.context": "https://api.server.com?$select=ListingKey,Appliances&$filter=Appliances/all(l:l eq 'Washer')",
  "value": [{
    "ListingKey": "a1",
    "Appliances": ["Washer", "Dryer"]
  }, {
    "ListingKey": "b2,
    "Appliances": ["Dryer"]
  }]
}
```  