### PR TITLE
Issue #47 - allow Edm.String and Collection(Edm.String) for Single and Multi lookups

### DIFF
--- a/sample-web-api-server.core.1.0.2.resoscript
+++ b/sample-web-api-server.core.1.0.2.resoscript
@@ -181,9 +181,6 @@
     <Parameter Name="TopCount" Value="5"/>
     <Parameter Name="SortCount" Value="20"/>
 
-    <!-- New Values for WS103 Testing -->
-    <Parameter Name="CastFieldType" Value="Edm.String"/>
-
     <!-- Required resource lists for Standard Resource Names requirement -->
     <Parameter Name="WebAPI102_RequiredResourceList" Value="Property,Member,Office,Media"/>
 

--- a/src/main/java/org/reso/certification/features/web-api/web-api-server.core.1.0.2.feature
+++ b/src/main/java/org/reso/certification/features/web-api/web-api-server.core.1.0.2.feature
@@ -413,7 +413,7 @@ Feature: Web API Server 1.0.2 Core Certification
     And the response has results
     And resource metadata for "Parameter_EndpointResource" contains the fields in the given select list
     And data are present for fields contained within the given select list
-    And Multiple Valued Enumeration Data in "Parameter_MultipleValueLookupField" has "Parameter_MultipleLookupValue1"
+    And Multiple Valued Enumeration Data in "Parameter_MultipleValueLookupField" is empty OR has "Parameter_MultipleLookupValue1"
 
   @filter-enum-single-has @2.4.9
   Scenario: filter-enum-single-has - Support Single Value Lookups

--- a/src/main/java/org/reso/commander/common/TestUtils.java
+++ b/src/main/java/org/reso/commander/common/TestUtils.java
@@ -866,6 +866,7 @@ public final class TestUtils {
     public static final class ODataTypes {
       public static final String
           STRING = "Edm.String",
+          STRING_COLLECTION = "Collection(Edm.String)",
           DATE = "Edm.Date",
           DECIMAL = "Edm.Decimal",
           DOUBLE = "Edm.Double",


### PR DESCRIPTION
Adds support for `Edm.String` and `Collection(Edm.String)` in RESO Data Dictionary 1.7+. 

See issue #47 for further details.