### PR TITLE
Timestamp/Date comparisons between nulls and records with values

### DIFF
--- a/src/main/java/org/reso/certification/stepdefs/WebAPIServer.java
+++ b/src/main/java/org/reso/certification/stepdefs/WebAPIServer.java
@@ -656,9 +656,9 @@ class WebAPIServer implements En {
         from(getTestContainer().getResponseData()).getList(JSON_VALUE_PATH, HashMap.class).forEach(item -> {
           try {
             if (count.get() == 0) {
-              initialValue.set(TestUtils.parseTimestampFromEdmDateTimeOffsetString(item.get(fieldName).toString()));
+              initialValue.set(TestUtils.parseTimestampFromEdmDateTimeOffsetString((String)item.get(fieldName)));
             } else {
-              currentValue.set(TestUtils.parseTimestampFromEdmDateTimeOffsetString(item.get(fieldName).toString()));
+              currentValue.set(TestUtils.parseTimestampFromEdmDateTimeOffsetString((String)item.get(fieldName)));
               if (orderBy.get().equals(ASC)) {
                 assertTrue(TestUtils.compare(initialValue.get(), LESS_THAN_OR_EQUAL, currentValue.get()));
               } else if (orderBy.get().equals(DESC)) {


### PR DESCRIPTION
Fixes Issue #60.

Note that the comparisons between null timestamps/dates and ones with values was working as expected in this case, as outlined by the [OData spec](http://docs.oasis-open.org/odata/odata/v4.01/csprd02/part2-url-conventions/odata-v4.01-csprd02-part2-url-conventions.html#sec_GreaterThan). 

Greater than and the other comparison operators are supposed to return false if one value is null and the other has a value. 

There was an issue, however, in that we were attempting to access properties when the underlying object was `null` and that's what was throwing an exception. This should be fixed now. cc: @dgmyrek 