### PR TITLE
Issue #82: refactored availability report to use frequencies and track lookups at a granular level

### DIFF
--- a/src/main/java/org/reso/certification/codegen/DDCacheProcessor.java
+++ b/src/main/java/org/reso/certification/codegen/DDCacheProcessor.java
@@ -2,21 +2,20 @@ package org.reso.certification.codegen;
 
 import org.reso.models.ReferenceStandardField;
 
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class DDCacheProcessor extends WorksheetProcessor {
-  Map<String, List<ReferenceStandardField>> standardFieldCache = new LinkedHashMap<>();
+  final AtomicReference<Map<String, Map<String, ReferenceStandardField>>> standardFieldCache =
+      new AtomicReference<>(Collections.synchronizedMap(new LinkedHashMap<>()));
 
   private void addToFieldCache(ReferenceStandardField field) {
-    standardFieldCache.putIfAbsent(field.getParentResourceName(), new LinkedList<>());
-    standardFieldCache.get(field.getParentResourceName()).add(field);
+    standardFieldCache.get().putIfAbsent(field.getParentResourceName(), new LinkedHashMap<>());
+    standardFieldCache.get().get(field.getParentResourceName()).put(field.getStandardName(), field);
   }
 
-  public Map<String, List<ReferenceStandardField>> getStandardFieldCache() {
-    return standardFieldCache;
+  public Map<String, Map<String, ReferenceStandardField>> getStandardFieldCache() {
+    return standardFieldCache.get();
   }
 
   @Override

--- a/src/main/java/org/reso/certification/codegen/DataDictionaryCodeGenerator.java
+++ b/src/main/java/org/reso/certification/codegen/DataDictionaryCodeGenerator.java
@@ -31,6 +31,8 @@ public class DataDictionaryCodeGenerator {
 
   /**
    * Generates Data Dictionary references for local workbook instance using the configured WorksheetProcessor
+   *
+   *  TODO: convert to .parallelStream()
    */
   public void processWorksheets() {
     Sheet currentWorksheet, standardResourcesWorksheet;

--- a/src/main/java/org/reso/certification/codegen/WorksheetProcessor.java
+++ b/src/main/java/org/reso/certification/codegen/WorksheetProcessor.java
@@ -353,6 +353,7 @@ public abstract class WorksheetProcessor {
     //enumerations.forEach((key, items) -> LOG.info("key: " + key + " , items: " + items.toString()));
   }
 
+  //TODO: convert to parallel stream
   public void buildStandardRelationships(Sheet worksheet) {
     int FIRST_ROW_INDEX = 1;
     Row currentRow;

--- a/src/main/java/org/reso/models/LookupValue.java
+++ b/src/main/java/org/reso/models/LookupValue.java
@@ -1,0 +1,42 @@
+package org.reso.models;
+
+import java.util.Objects;
+
+public final class LookupValue {
+  private final String resourceName;
+  private final String fieldName;
+  private final String lookupValue;
+
+  public LookupValue(String resourceName, String fieldName, String lookupValue) {
+    this.resourceName = resourceName;
+    this.fieldName = fieldName;
+    this.lookupValue = lookupValue;
+  }
+
+  public String getResourceName() {
+    return resourceName;
+  }
+
+  public String getFieldName() {
+    return fieldName;
+  }
+
+  public String getLookupValue() {
+    return lookupValue;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    LookupValue that = (LookupValue) o;
+    return resourceName.equals(that.resourceName) &&
+        fieldName.equals(that.fieldName) &&
+        lookupValue.equals(that.lookupValue);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(resourceName, fieldName, lookupValue);
+  }
+}


### PR DESCRIPTION
Updated Availability Report to use frequencies instead of availability to preserve precision for use with other aggregates. Added sections for specific lookup frequencies and rollups. 

Structure: 
resources: has resource perf stats and field rollups. 
fields: has field frequency values
lookups: has lookup rollups 
lookupValues: has lookup frequency values