### PR TITLE
#137: Add additional logging for lookup resource tests

### DIFF
--- a/src/main/java/org/reso/certification/containers/WebAPITestContainer.java
+++ b/src/main/java/org/reso/certification/containers/WebAPITestContainer.java
@@ -706,15 +706,23 @@ public final class WebAPITestContainer implements TestContainer {
   }
 
   private void processODataRequestException(ODataClientErrorException exception) {
-    LOG.error("ODataClientErrorException caught. Check tests for asserted conditions...");
-    LOG.error(exception);
+    /*
+      TODO: determine whether these additional lines are needed or whether the bubbled error is sufficient
+      LOG.error("ODataClientErrorException caught. Check tests for asserted conditions...");
+      LOG.error(exception);
+     */
+
     setODataClientErrorException(exception);
     setServerODataHeaderVersion(TestUtils.getHeaderData(HEADER_ODATA_VERSION, Arrays.asList(exception.getHeaderInfo())));
     setResponseCode(exception.getStatusLine().getStatusCode());
   }
 
   private void processODataRequestException(ODataServerErrorException exception) {
-    LOG.error("ODataServerErrorException thrown in executeGetRequest. Check tests for asserted conditions...");
+    /*
+      TODO: determine whether these additional lines are needed or whether the bubbled error is sufficient
+      LOG.error("ODataServerErrorException thrown in executeGetRequest. Check tests for asserted conditions...");
+     */
+
     //TODO: look for better ways to do this in Olingo or open PR
     if (exception.getMessage().contains(Integer.toString(HttpStatus.SC_NOT_IMPLEMENTED))) {
       setResponseCode(HttpStatus.SC_NOT_IMPLEMENTED);

--- a/src/main/java/org/reso/certification/stepdefs/LookupResource.java
+++ b/src/main/java/org/reso/certification/stepdefs/LookupResource.java
@@ -24,8 +24,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 import static org.reso.certification.stepdefs.DataAvailability.CERTIFICATION_RESULTS_PATH;
+import static org.reso.commander.common.ErrorMsg.getDefaultErrorMessage;
 import static org.reso.commander.common.ODataUtils.*;
 import static org.reso.commander.common.TestUtils.failAndExitWithErrorMessage;
 import static org.reso.commander.common.Utils.wrapColumns;
@@ -164,8 +166,11 @@ public class LookupResource {
     });
 
     if (fieldsWithMissingAnnotations.size() > 0) {
-      failAndExitWithErrorMessage("The following fields are missing the required '" + annotationTerm + "' annotation: "
-          + wrapColumns("\t" + String.join(", ", fieldsWithMissingAnnotations)), LOG);
+      final String msg = "The following fields are missing the required '" + annotationTerm + "' annotation: "
+          + wrapColumns(String.join(", ", fieldsWithMissingAnnotations)) + "\n";
+
+      LOG.error(getDefaultErrorMessage(msg));
+      fail(msg);
     }
   }
 
@@ -188,21 +193,14 @@ public class LookupResource {
     final Set<String> missingLookupNames = Utils.getDifference(annotatedLookupNames, lookupNamesFromLookupData);
 
     if (missingLookupNames.size() > 0) {
-      failAndExitWithErrorMessage("The following fields have LookupName annotations but are missing from the Lookup Resource: "
-          + wrapColumns("\t" + String.join(", ", missingLookupNames)), LOG);
-    }
+      final String msg = "The following fields have LookupName annotations but are missing from the Lookup Resource: "
+          + wrapColumns(String.join(", ", missingLookupNames)) + "\n";
 
-    if (filteredResourceFieldMap.size() > 0) {
+      LOG.error(getDefaultErrorMessage(msg));
+      fail(msg);
+    } else {
       scenario.log("Found all annotated LookupName elements in the Lookup data. Unique count: " + annotatedLookupNames.size());
       scenario.log("LookupNames: " + wrapColumns(String.join(", ", annotatedLookupNames)));
-
-      /*
-        TODO: only produce the field JSON file in DEBUG mode
-            Utils.createFile(CERTIFICATION_RESULTS_PATH, LOOKUP_RESOURCE_FIELD_METADATA_FILE_NAME,
-                ODataUtils.serializeFieldMetadataForLookupFields(filteredResourceFieldMap).toString());
-       */
-    } else {
-      failAndExitWithErrorMessage("No annotated lookup names found in the OData XML Metadata.", LOG);
     }
   }
 }

--- a/src/main/java/org/reso/commander/Commander.java
+++ b/src/main/java/org/reso/commander/Commander.java
@@ -549,27 +549,24 @@ public class Commander {
    * @return a URI with the metadata path included
    */
   public URI getPathToMetadata(String requestUri) {
-    if (requestUri == null) {
-      LOG.error(getDefaultErrorMessage("service root is null!"));
-      System.exit(NOT_OK);
-    }
-
-    try {
-      String uri = requestUri;
-      if (!requestUri.contains(METADATA_PATH)) {
-        uri += METADATA_PATH;
+    if (requestUri == null || requestUri.length() == 0) {
+      TestUtils.failAndExitWithErrorMessage("OData service root is missing!", LOG);
+    } else {
+      try {
+        String uri = requestUri;
+        if (!requestUri.contains(METADATA_PATH)) {
+          uri += METADATA_PATH;
+        }
+        return new URI(uri).normalize();
+      } catch (Exception ex) {
+        TestUtils.failAndExitWithErrorMessage("Could not create metadata URI.\n\t" + ex, LOG);
       }
-      return new URI(uri);
-    } catch (Exception ex) {
-      LOG.error(getDefaultErrorMessage("could not create path to metadata.\n" + ex.toString()));
-      System.exit(NOT_OK);
     }
-
     return null;
   }
 
   /**
-   * Executes an OData GET Request w ith the current Commander instance
+   * Executes an OData GET Request with the current Commander instance
    * @param wrapper the OData transport wrapper to use for the request
    * @return and OData transport wrapper with the response, or exception if one was thrown
    */


### PR DESCRIPTION
This PR adds additional logging for Lookup Resource tests. Error information will show up in the `commander.log` file in addition to the HTML artifacts generated from testing. Additionally, Data Dictionary tests no longer "fast fail" on Lookup Resource errors as doing so short-circuits the rest of testing and affects error reports. 