### PR TITLE
#110: Skip has test for string enums

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 *.log
 *.iml
 .run/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ explains how to run the following tests:
 
 * Data Dictionary 1.7
 * Data Dictionary Availability Report
-* IDX Payload 1.7
 * Web API Core 2.0.0
 
 ## [Command-Line OData Web API Tools](/doc/CLI.md)

--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,7 @@ tasks.register('testWebApiCore_2_0_0') {
       '\nExample: ' +
       '\n  ./gradlew testWebApiCore_2_0_0 -DpathToRESOScript=/path/to/web-api-core-2.0.0.resoscript -DshowResponses=true' +
       '\n\nNote: by default the Web API tests assume Collection(Edm.EnumType).' +
+      '\nPass -DuseStringEnums=true if using string enumerations and the Lookup Resource.' +
       '\nPass -DuseCollections=false if using OData IsFlags.' +
       '\n\n[Report location: ' + certReportsDir + ']' +
       '\n\n'

--- a/doc/Certification.md
+++ b/doc/Certification.md
@@ -11,7 +11,11 @@ The RESO Commander is the basis for automated Data Dictionary, Payloads, and Web
 
 
 ## Java and the JDK
-To run the Commander as an _automated testing tool_, the Java JDK must be installed. The Commander has been tested with JDK 1.8 and 10 at this point. Those using JDK 11+, please [report issues](https://github.com/RESOStandards/web-api-commander/issues) if they arise.
+To run the Commander as an _automated testing tool_, a Java 64-bit JDK must be installed.
+
+The Commander has been tested with JDK 1.8 and 10 at this point. 
+
+Those using JDK 11+, please [report issues](https://github.com/RESOStandards/web-api-commander/issues) if they arise.
 
 To see whether you have the JDK installed, type the following using your local command line environment:
 ```
@@ -87,6 +91,7 @@ RESO Certification tasks
 testDataAvailability_1_7 - Data Dictionary 1.7 Data Availability Tests
 Example:
   ./gradlew testDataAvailability_1_7 -DpathToRESOScript=/path/to/web-api-core-2.0.0.resoscript
+
 [Report location: build/certification/reports]
 
 
@@ -114,6 +119,7 @@ Example:
   ./gradlew testWebApiCore_2_0_0 -DpathToRESOScript=/path/to/web-api-core-2.0.0.resoscript -DshowResponses=true
 
 Note: by default the Web API tests assume Collection(Edm.EnumType).
+Pass -DuseStringEnums=true if using string enumerations and the Lookup Resource.
 Pass -DuseCollections=false if using OData IsFlags.
 
 [Report location: build/certification/reports]
@@ -143,7 +149,8 @@ These tasks will also produce reports in the local `/build/certification` direct
 
 This will run the Core tests against the Web API 2.0.0 Server provided as `WebAPIURI` in your `web-api-server.core.2.0.0.resoscript` file.
 
-**Note**: by default, the Commander uses `Collection(Edm.EnumType)` for multiple enumerations testing. 
+**Note**: by default, the Commander assumes `Edm.EnumType` for single- and `Collection(Edm.EnumType)` for multiple-enumeration testing.
+Pass `-DuseStringEnums=true` if you are using string enumerations.
 Pass `-DuseCollections=false` if you are using `IsFlags="true"` instead.
 
 ##### MacOS or Linux

--- a/src/main/java/org/reso/certification/stepdefs/WebAPIServerCore.java
+++ b/src/main/java/org/reso/certification/stepdefs/WebAPIServerCore.java
@@ -57,6 +57,7 @@ public class WebAPIServerCore implements En {
   private static final Logger LOG = LogManager.getLogger(WebAPIServerCore.class);
   private static final String
       SHOW_RESPONSES_PARAM = "showResponses",
+      USE_STRING_ENUMS_PARAM = "useStringEnums",
       USE_COLLECTIONS_PARAM = "useCollections";
 
   private static final String PATH_TO_RESOSCRIPT_KEY = "pathToRESOScript";
@@ -67,6 +68,7 @@ public class WebAPIServerCore implements En {
   // boolean used for indicating whether Web API tests are using collections of enums or not
   // defaults to useCollections=true since IsFlags is being deprecated
   private static final boolean useCollections = Boolean.parseBoolean(System.getProperty(USE_COLLECTIONS_PARAM, "true"));
+  private static final boolean useStringEnums = Boolean.parseBoolean(System.getProperty(USE_STRING_ENUMS_PARAM, "false"));
 
   /*
    * Used to store a static instance of the WebAPITestContainer class
@@ -287,8 +289,12 @@ public class WebAPIServerCore implements En {
       final Set<String> collectionRequestIds = new HashSet<>(Arrays.asList("filter-coll-enum-any", "filter-coll-enum-all"));
       final Set<String> isFlagsRequestIds = new HashSet<>(Arrays.asList("filter-enum-multi-has", "filter-enum-multi-has-and"));
 
+      if (useStringEnums) {
+        assumeFalse("Using string enumerations. Skipping Test: " + requestId, requestId.contentEquals("filter-enum-single-has"));
+      }
+
       if (useCollections) {
-        assumeFalse("Using Collection(Edm.EnumType). Skipping Test: " + requestId, isFlagsRequestIds.contains(requestId));
+        assumeFalse("Using Collections for enumerations. Skipping Test: " + requestId, isFlagsRequestIds.contains(requestId));
       } else {
         assumeFalse("Using IsFlags=\"true\". Skipping Test: " + requestId, collectionRequestIds.contains(requestId));
       }


### PR DESCRIPTION
Adds support for an additional flag for those using string enumerations. 

Pass `-DuseStringEnums=true` in order to skip the has test.