### PR TITLE
#160: Remove odata-openapi submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "odata-openapi"]
-	path = odata-openapi
-	url = https://github.com/oasis-tcs/odata-openapi.git


### PR DESCRIPTION
Removed the OData Open API submodules as they're no longer being used by the project.