### PR TITLE
#162 Change warning to error in metadata validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,7 +156,7 @@ tasks.register('testDataDictionary_1_7') {
   dependsOn jar, prepareCertificationEnvironment
   doLast {
     javaexec {
-      main = 'io.cucumber.core.cli.Main'
+      mainClass = 'io.cucumber.core.cli.Main'
       classpath = configurations.cucumberRuntime + sourceSets.main.output + sourceSets.test.output
       systemProperties = System.getProperties()
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
   //TODO: choose one schema validator between this and rest-assured
   implementation 'com.networknt:json-schema-validator:1.0.70'
   implementation 'com.google.code.gson:gson:2.9.0'
-  implementation 'org.apache.commons:commons-text:1.9'
+  implementation 'org.apache.commons:commons-text:1.10.0'
 
 }
 

--- a/src/main/java/org/reso/commander/jsonSerializers/FieldJson.java
+++ b/src/main/java/org/reso/commander/jsonSerializers/FieldJson.java
@@ -7,6 +7,7 @@ import org.apache.olingo.commons.api.edm.EdmAnnotation;
 import org.apache.olingo.commons.api.edm.EdmElement;
 import org.apache.olingo.commons.api.edm.EdmProperty;
 import org.reso.commander.common.ODataUtils;
+import static org.reso.commander.common.TestUtils.failAndExitWithErrorMessage;
 
 import java.lang.reflect.Type;
 import java.util.List;
@@ -122,8 +123,9 @@ public final class FieldJson implements JsonSerializer<FieldJson> {
       typeName = src.edmElement.getType().getFullQualifiedName().getFullQualifiedNameAsString();
       field.addProperty(TYPE_KEY, typeName);
     } catch (Exception ex) {
+      //Issue #162: Need to fail on serialization exceptions since Olingo metadata validation might not catch them
       LOG.error(getDefaultErrorMessage("Field Name:", src.edmElement.getName(), ex.toString()));
-      field.addProperty(TYPE_KEY, "UNDEFINED");
+      failAndExitWithErrorMessage(ex.toString(), LOG);
     }
 
     field.addProperty(NULLABLE_KEY, ((EdmProperty) src.edmElement).isNullable());

--- a/src/main/java/org/reso/commander/jsonSerializers/FieldJson.java
+++ b/src/main/java/org/reso/commander/jsonSerializers/FieldJson.java
@@ -118,7 +118,7 @@ public final class FieldJson implements JsonSerializer<FieldJson> {
     field.addProperty(RESOURCE_NAME_KEY, src.resourceName);
     field.addProperty(FIELD_NAME_KEY, src.edmElement.getName());
 
-    String typeName = null;
+    String typeName;
     try {
       typeName = src.edmElement.getType().getFullQualifiedName().getFullQualifiedNameAsString();
       field.addProperty(TYPE_KEY, typeName);


### PR DESCRIPTION
Fixes #162.

There was an issue where OData metadata wasn't really valid, but not handled by the Olingo validation portion and only caught during serialization. Previously, there was a warning in this case but the change is to make it fast fail and leave an error in the log since metadata isn't valid if its EDM elements cannot be resolved.